### PR TITLE
Update to re-render when svgXmlData and fill props change

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const ACEPTED_SVG_ELEMENTS = [
 ];
 
 // Attributes from SVG elements that are mapped directly.
-const SVG_ATTS = ['viewBox'];
+const SVG_ATTS = ['viewBox', 'width', 'height'];
 const G_ATTS = ['id'];
 const CIRCLE_ATTS = ['cx', 'cy', 'r', 'fill', 'stroke'];
 const PATH_ATTS = ['d', 'fill', 'stroke'];

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class SvgUri extends Component{
 	constructor(props){
 		super(props);
 
-    this.state = {svgXmlData: props.svgXmlData};
+    this.state = {fill: props.fill, svgXmlData: props.svgXmlData};
 
     this.createSVGElement     = this.createSVGElement.bind(this);
     this.obtainComponentAtts  = this.obtainComponentAtts.bind(this);
@@ -83,9 +83,17 @@ class SvgUri extends Component{
     if (nextProps.source) {
         const source = resolveAssetSource(nextProps.source) || {};
         const oldSource = resolveAssetSource(this.props.source) || {};
-        if(source.uri !== oldSource.uri){
+        if (source.uri !== oldSource.uri){
             this.fecthSVGData(source.uri);
         }
+    }
+
+    if (nextProps.svgXmlData !== this.props.svgXmlData) {
+      this.setState({ svgXmlData: nextProps.svgXmlData });
+    }
+
+    if (nextProps.fill !== this.props.fill) {
+      this.setState({ fill: nextProps.fill });
     }
   }
 
@@ -157,7 +165,7 @@ class SvgUri extends Component{
       .filter(utils.getEnabledAttributes(enabledAttributes))
       .reduce((acc, {nodeName, nodeValue}) => ({
         ...acc,
-        [nodeName]: this.props.fill && nodeName === 'fill' ? this.props.fill : nodeValue,
+        [nodeName]: this.state.fill && nodeName === 'fill' ? this.state.fill : nodeValue,
       }), {});
   }
 


### PR DESCRIPTION
This PR does the following:
- It updates the component to re-render when the `svgXmlData` and `fill` props change.
- Fix the svg `width` and `height` attrs missing.