### PR TITLE
Support classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ react-native link react-native-svg # not react-native-svg-uri !!!
 | `source` | `ImageSource` |  | Same kind of `source` prop that `<Image />` component has
 | `svgXmlData` | `String` |  | You can pass the SVG as String directly
 | `fill` | `Color` |  | Overrides all fill attributes of the svg file
+| `classes` | `Object` |  | Overrides attributes of classes (only overrides those attributes present in the given object)
 
 ## Known Bugs
 

--- a/utils.js
+++ b/utils.js
@@ -19,3 +19,44 @@ export const transformStyle = ({nodeName, nodeValue, fillProp}) => {
 };
 
 export const getEnabledAttributes = enabledAttributes => ({nodeName}) => enabledAttributes.includes(camelCase(nodeName));
+
+export const extractStyleClasses = (node) => {
+
+    if (node.nodeName === 'style') {
+        let stylesString = node.firstChild.nodeValue;
+        let classArray = stylesString.split('}');
+
+        return classArray.reduce((acc, classObj) => {
+            let [className, style] = classObj.split('{');
+            if (className === '') {
+                return acc;
+            }
+            className = className.substring(1);
+            return {...acc, [className]: extractStyle(style)};
+        }, {})
+    } else {
+        if (node.childNodes) {
+            let result = false;
+            for (let i = 0; i < node.childNodes.length; i++) {
+                result = extractStyleClasses(node.childNodes[i]);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+
+        return false;
+    }
+};
+
+export const extractStyle = (style, fillProp) => {
+    return style.split(';')
+        .reduce((acc, attribute) => {
+            const [property, value] = attribute.split(':');
+            if (property === '') {
+                return acc;
+            } else {
+                return {...acc, [camelCase(property)]: fillProp && property === 'fill' ? fillProp : value};
+            }
+        }, {});
+};


### PR DESCRIPTION
This adds support for classes defined in a svg using the style tag:
`<style>.cls-1{stroke:#b2b4b9;stroke-linecap:round;stroke-miterlimit:10;stroke-width:1.5px;}.cls-2{fill:#f9bc35;}</style>`

Attributes of these classes can also be overridden using the following syntax
`<SvgUri classes={{'cls-1': {stroke: 'blue'}}} ... />`
This will override the stroke color of the class cls-1 other attributes remain untouched.