### PR TITLE
Fix: Text elements / transform + clipPath attribute added

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,13 +140,13 @@ class SvgUri extends Component{
 
     return responseXML;
   }
-   
-  // Remove empty strings from children array  
+
+  // Remove empty strings from children array
   trimElementChilden(children) {
     for (child of children) {
       if (typeof child === 'string') {
-        if (child.trim.length === 0)
-          children.splice(children.indexOf(child), 1); 
+        if (child.trim().length === 0)
+          children.splice(children.indexOf(child), 1);
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -203,9 +203,6 @@ class SvgUri extends Component{
       return <Polyline key={i} {...componentAtts}>{childs}</Polyline>;
     case 'text':
       componentAtts = this.obtainComponentAtts(node, TEXT_ATTS);
-      if (componentAtts.y) {
-        componentAtts.y = fixYPosition(componentAtts.y, node)
-      }
       return <Text key={i} {...componentAtts}>{childs}</Text>;
     case 'tspan':
       componentAtts = this.obtainComponentAtts(node, TEXT_ATTS);

--- a/index.js
+++ b/index.js
@@ -54,14 +54,14 @@ const RADIALG_ATTS = CIRCLE_ATTS.concat(['id', 'gradientUnits']);
 const STOP_ATTS = ['offset'];
 const ELLIPSE_ATTS = ['cx', 'cy', 'rx', 'ry'];
 
-const TEXT_ATTS = ['fontFamily', 'fontSize', 'fontWeight']
+const TEXT_ATTS = ['fontFamily', 'fontSize', 'fontWeight', 'textAnchor']
 
 const POLYGON_ATTS = ['points'];
 const POLYLINE_ATTS = ['points'];
 
 const COMMON_ATTS = ['fill', 'fillOpacity', 'stroke', 'strokeWidth', 'strokeOpacity', 'opacity',
     'strokeLinecap', 'strokeLinejoin',
-    'strokeDasharray', 'strokeDashoffset', 'x', 'y', 'rotate', 'scale', 'origin', 'originX', 'originY'];
+    'strokeDasharray', 'strokeDashoffset', 'x', 'y', 'rotate', 'scale', 'origin', 'originX', 'originY', 'transform', 'clipPath'];
 
 let ind = 0;
 


### PR DESCRIPTION
Hi,
here is a fix for the text element.

Commit: bc85a03
I think `trim().length` should be called instead of `trim.length`... all strings were filtered out.

Commit: 7f9c13f
added textAnchor to improve the alignment of text elements.
added transform e.g. to rotate an element
added clipPath to define clipping for an element.

Commit: 50ed807
removed unnecessary call of fixYPosition. There is nothing to fix when textAnchor used in the svg.

For me this fix works like a charm. 