### PR TITLE
Add ability to customize fill color

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ react-native link react-native-svg # not react-native-svg-uri !!!
 | `source` | `ImageSource` |  | Same kind of `source` prop that `<Image />` component has
 | `svgXmlData` | `String` |  | You can pass the SVG as String directly
 | `fill` | `Color` |  | Overrides all fill attributes of the svg file
+| `fillAll` | `Boolean` |  Adds the fill color to the entire svg object
 
 ## Known Bugs
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,11 @@ interface SvgUriProps {
      * Fill color for the svg object
      */
     fill?: string
+
+    /**
+     * Fill the entire svg element with same color
+     */
+    fillAll?: boolean
 }
 
 export default class SvgUri extends Component<SvgUriProps, {}> { }

--- a/index.js
+++ b/index.js
@@ -220,6 +220,11 @@ class SvgUri extends Component{
 
   obtainComponentAtts({attributes}, enabledAttributes) {
     const styleAtts = {};
+
+    if (this.state.fill && this.props.fillAll) {
+      styleAtts.fill = this.state.fill;
+    }
+
     Array.from(attributes).forEach(({nodeName, nodeValue}) => {
       Object.assign(styleAtts, utils.transformStyle({
         nodeName,
@@ -303,6 +308,7 @@ SvgUri.propTypes = {
   svgXmlData: PropTypes.string,
   source: PropTypes.any,
   fill: PropTypes.string,
+  fillAll: PropTypes.bool
 }
 
 module.exports = SvgUri;


### PR DESCRIPTION
Following the proposed solution detailed on https://github.com/vault-development/react-native-svg-uri/issues/86, this PR allows to defined a custom fill value for `svg` elements without any defined `fill` attribute