### PR TITLE
Set ind to zero on render

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ class SvgUri extends Component{
       if (this.state.svgXmlData == null) {
         return null;
       }
-
+      ind = 0
       const inputSVG = this.state.svgXmlData.substring(
         this.state.svgXmlData.indexOf("<svg "),
         (this.state.svgXmlData.indexOf("</svg>") + 6)


### PR DESCRIPTION
By not setting ind to zero, every svg component gets a different key on each render even when the component does not need to be updated. This means the whole svg is discarded by React and mounted again on each render which is costly.