### PR TITLE
Skip unsupported nodes even if they have text value

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,19 +140,8 @@ class SvgUri extends Component{
 
     return responseXML;
   }
-   
-  // Remove empty strings from children array  
-  trimElementChilden(children) {
-    for (child of children) {
-      if (typeof child === 'string') {
-        if (child.trim.length === 0)
-          children.splice(children.indexOf(child), 1); 
-      }
-    }
-  }
 
   createSVGElement(node, childs){
-    this.trimElementChilden(childs);
     let componentAtts = {};
     const i = ind++;
     switch (node.nodeName) {
@@ -247,6 +236,11 @@ class SvgUri extends Component{
       return null;
     }
 
+    const textValue = node.nodeValue;
+    if (textValue) {
+      return textValue;
+    }
+
     // Process the xml node
     const arrayElements = [];
 
@@ -254,14 +248,9 @@ class SvgUri extends Component{
     // Recursive function.
     if (node.childNodes && node.childNodes.length > 0){
         for (let i = 0; i < node.childNodes.length; i++){
-          const isTextValue = node.childNodes[i].nodeValue
-          if (isTextValue) {
-            arrayElements.push(node.childNodes[i].nodeValue)
-          } else {
-            const nodo = this.inspectNode(node.childNodes[i]);
-            if (nodo != null) {
-              arrayElements.push(nodo);
-            }
+          const nodo = this.inspectNode(node.childNodes[i]);
+          if (nodo != null) {
+            arrayElements.push(nodo);
           }
         }
     }


### PR DESCRIPTION
This PR fixes #112. It also removes the code added in #76 to fix #84, as it's no longer needed.

The main cause of both issues is that `inspectNode()` function fails to exclude children of unsupported node types if they have some value. This leads to nodes of type `#text` (#84) and `#comment` (#112) being included into the resulting document as raw text, which, in turn, produces the `Raw text cannot be used outside of a <Text> tag` error.

Here's what happens: in the very beginning of `inspectNode()` function, there is [a check](https://github.com/vault-development/react-native-svg-uri/blob/1e8b8d8/index.js#L246) for inclusion of the node type into `ACCEPTED_SVG_ELEMENTS` array. If it's not inside the array, `null` is returned. In a cycle inside the same function, there is [another check](https://github.com/vault-development/react-native-svg-uri/blob/1e8b8d8/index.js#L262) that doesn't include child into resulting array if recursive call to `inspectNode()` returned null.

But, inside the same loop, there is [a code](https://github.com/vault-development/react-native-svg-uri/blob/1e8b8d8/index.js#L258) that adds child node's value into the children array if the node has one. It runs before recursing into `inspectNode()`, which leads to check for whether node type is supported being skipped for all nodes that have value.

This PR fixes the issue by making sure that the check for whether node type is supported runs for all child nodes, regardless of whether that have `nodeValue` set.