### PR TITLE
Add `viewBox` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,13 @@ interface SvgUriProps {
      * Fill the entire svg element with same color
      */
     fillAll?: boolean
+
+    /**
+     * The viewBox attribute allows you to specify that a given
+     * set of graphics stretch to fit a particular container element
+     * e.g. viewBox={'0 0 24 24'} to fit 24x24 square
+     */
+    viewBox?: string
 }
 
 export default class SvgUri extends Component<SvgUriProps, {}> { }

--- a/index.js
+++ b/index.js
@@ -165,6 +165,10 @@ class SvgUri extends Component{
         componentAtts.height = this.props.height;
       }
 
+      if (this.props.viewBox) {
+        componentAtts.viewBox = this.props.viewBox;
+      }
+
       return <Svg key={i} {...componentAtts}>{childs}</Svg>;
     case 'g':
       componentAtts = this.obtainComponentAtts(node, G_ATTS);


### PR DESCRIPTION
The viewBox attribute allows you to specify that a given set of graphics stretch to fit a particular container element