### PR TITLE
#106# fix `child is not defined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class SvgUri extends Component{
 
   // Remove empty strings from children array
   trimElementChilden(children) {
-    for (child of children) {
+    for (let child of children) {
       if (typeof child === 'string') {
         if (child.trim.length === 0)
           children.splice(children.indexOf(child), 1);


### PR DESCRIPTION
child is not defined in `trimElementChilden()`