### PR TITLE
Fix trimElementChilden

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,16 +149,15 @@ class SvgUri extends Component{
 
   // Remove empty strings from children array
   trimElementChilden(children) {
-    for (child of children) {
-      if (typeof child === 'string') {
-        if (child.trim.length === 0)
-          children.splice(children.indexOf(child), 1);
-      }
-    }
+    return children.filter( (child) => {
+      if (typeof child !== "string") return true;
+      if (child.trim().length > 0) return true;
+      return false;
+    });
   }
 
   createSVGElement(node, childs){
-    this.trimElementChilden(childs);
+    childs = this.trimElementChilden(childs);
     let componentAtts = {};
     const i = ind++;
     switch (node.nodeName) {


### PR DESCRIPTION
In some cases, not all empty children were removed.

This pull request fixes issue with image https://haveibeenpwned.com/Content/Images/PwnedLogos/EpicGames.svg