### PR TITLE
fix: Solved version crash by replacing componentWillReceiveProps method

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,21 +103,28 @@ class SvgUri extends Component{
     this.isComponentMounted = true;
   }
 
-  componentWillReceiveProps (nextProps){
-    if (nextProps.source) {
-      const source = resolveAssetSource(nextProps.source) || {};
-      const oldSource = resolveAssetSource(this.props.source) || {};
-      if(source.uri !== oldSource.uri){
-        this.fetchSVGData(source.uri);
-      }
+  static getDerivedStateFromProps(nextProps, state){
+    const newState = {};
+
+    if (nextProps.svgXmlData !== state.svgXmlData) {
+      Object.assign(newState, { svgXmlData: nextProps.svgXmlData });
     }
 
-    if (nextProps.svgXmlData !== this.props.svgXmlData) {
-      this.setState({ svgXmlData: nextProps.svgXmlData });
+    if (nextProps.fill !== state.fill) {
+      Object.assign(newState, { fill: nextProps.fill });
     }
 
-    if (nextProps.fill !== this.props.fill) {
-      this.setState({ fill: nextProps.fill });
+    return Object.keys(newState).length > 0 ? newState : null;
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { source } = this.props;
+    if (source) {
+        const newSource = resolveAssetSource(source) || {};
+        const oldSource = prevState.source && resolveAssetSource(prevProps.source) || {};
+        if (newSource.uri !== oldSource.uri){
+          this.fetchSVGData(newSource.uri);
+        }
     }
   }
 
@@ -150,8 +157,8 @@ class SvgUri extends Component{
   // Remove empty strings from children array
   trimElementChilden(children) {
     for (child of children) {
-      if (typeof child === 'string') { 
-        if (child.trim().length === 0) 
+      if (typeof child === 'string') {
+        if (child.trim().length === 0)
           children.splice(children.indexOf(child), 1);
       }
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "xmldom": "^0.1.22"
   },
   "peerDependencies": {
+    "react": "^16.3.0",
     "react-native-svg": "^5.3.0"
   },
   "bugs": {


### PR DESCRIPTION
Due to the new React versions tagging this method as UNSAFE, code will simply not work due to unhandled component exceptions.

This PR solves this by splitting the old componentWillReceiveProps between getDerivedStateFromProps & componentWillUpdate lifecycle hooks.

Feel free to comment or add any other change that would be worth it regarding version upgrade.