### PR TITLE
Handling warning to rename componentWillMount to UNSAFE_componentWill…

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,11 +99,11 @@ class SvgUri extends Component{
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.isComponentMounted = true;
   }
 
-  componentWillReceiveProps (nextProps){
+  UNSAFE_componentWillReceiveProps (nextProps){
     if (nextProps.source) {
       const source = resolveAssetSource(nextProps.source) || {};
       const oldSource = resolveAssetSource(this.props.source) || {};


### PR DESCRIPTION
Handling warning to rename componentWillMount to UNSAFE_componentWillMount, and componentWillReceiveProps to UNSAFE_componentWillReceiveProps.

Log WARN
```
 LOG  Running "RN-APP" with {"rootTag":1}
 WARN  Warning: componentWillMount has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: SvgUri
 WARN  Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: SvgUri
```